### PR TITLE
Fix get_ebi_url() for Run IDs w/ 11 characters

### DIFF
--- a/download-sra
+++ b/download-sra
@@ -16,6 +16,8 @@ get_ebi_url(){
   local pdir="${base}/$(echo ${id:0:3} | tr [:upper:] [:lower:])/${id:0:6}"
   if test $(printf ${id} | wc -c) -eq 10; then
     local url="${pdir}/00${id: -1}/${id}"
+  elif test $(printf ${id} | wc -c) -eq 11; then
+    local url="${pdir}/0${id: -2}/${id}"
   else
     local url="${pdir}/${id}"
   fi


### PR DESCRIPTION
Recently, Run IDs with 11 characters have started to be used. So, I added the case when a Run ID has 11 characters.


## (cf.) `get_ebi_url()` result for Run ID with 10 characters

```
$ get_ebi_url "SRR5516338" 
ftp://ftp.sra.ebi.ac.uk/vol1/srr/SRR551/008/SRR5516338
```

## `get_ebi_url()` result for Run ID with 11 characters

Previous `get_ebi_url()` result (No .sra file can be downloaded with this url):

```
$ get_ebi_url "SRR12594136" # Run ID with 11 characters
ftp://ftp.sra.ebi.ac.uk/vol1/srr/SRR125/SRR12594136
```

New `get_ebi_url()` result:

```
$ get_ebi_url "SRR12594136" # Run ID with 11 characters
ftp://ftp.sra.ebi.ac.uk/vol1/srr/SRR125/036/SRR12594136
```